### PR TITLE
Remove git option from alias of ll and la

### DIFF
--- a/conf.d/alias.fish
+++ b/conf.d/alias.fish
@@ -9,8 +9,8 @@ and alias git 'hub'
 # ls
 command -q -s 'exa'
 and alias ls 'exa'
-and alias ll 'exa -lh --git'
-and alias la 'exa -alh --git'
+and alias ll 'exa -lh'
+and alias la 'exa -alh'
 
 # mkdir
 alias mk 'command mkdir -p'


### PR DESCRIPTION
Because output is very slow when the repository is huge.